### PR TITLE
Allow custom version label prefix using options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Default: none
 The local credential profile to use for the AWS SDK (see "Using Profiles with the SDK" section of the
  [Node AWS SDK docs](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).)
 
+#### options.prefix
+Type: `String`
+Default value: `null`
+
+A string to prefix the version label. If the value is `null`, `options.application` is used instead.
+
 ### Usage Examples
 
 #### Single Environment Deployment

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Default value: `null`
 
 A string to prefix the version label. If the value is `null`, `options.application` is used instead.
 
+#### options.suffix
+Type: `String`|`Array[String]`
+Default value: `['date','rev','rand']`
+
+The identifier to append to the version label. If the value is an array of suffix keys, each value is processed and appended with a '-' in between each identifier. 
+
+Valid suffix keys:
+
+- date - the current date in the format YYYYMMDD
+- rev - the git revision number
+- rand - a random numeric identifier
+
 ### Usage Examples
 
 #### Single Environment Deployment

--- a/tasks/ebDeploy.js
+++ b/tasks/ebDeploy.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
               '-' + rev +
               '-' + Math.floor((Math.random() * 899999) + 100000);
 
-            var label = (options.prefix || options.application) + '-' + version;
+            var label = grunt.template.process(options.prefix || options.application || '') + '-' + version;
 
             var account = data.User.Arn.split(/:/)[4];
             var bucket = 'elasticbeanstalk-' + options.region + '-' + account;

--- a/tasks/ebDeploy.js
+++ b/tasks/ebDeploy.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       archive: '.tmp/dist.zip',
-      region: 'us-east-1'
+      region: 'us-east-1',
+      suffix: ['date', 'rev', 'rand']
     });
 
     compress.options = {
@@ -53,19 +54,36 @@ module.exports = function(grunt) {
           done(false);
 
         } else {
-
           git.short(function(rev) { 
 
-            var date = new Date();
-            var y = date.getFullYear();
-            var m = date.getMonth() + 1;
-            var d = date.getDate();
+            var suffixes = {
+              date: function () {
+                var date = new Date();
+                var y = date.getFullYear();
+                var m = date.getMonth() + 1;
+                var d = date.getDate();
+                return String(y)
+                  + String(m = (m < 10) ? ('0' + m) : m)
+                  + String(d = (d < 10) ? ('0' + d) : d);
+              },
 
-            var version = String(y) +
-              String(m = (m < 10) ? ('0' + m) : m) +
-              String(d = (d < 10) ? ('0' + d) : d) +
-              '-' + rev +
-              '-' + Math.floor((Math.random() * 899999) + 100000);
+              rand: function () {
+                return Math.floor((Math.random() * 899999) + 100000);
+              },
+
+              rev: function () {
+                return rev;
+              }
+            };
+
+            var version = '';
+            if (typeof options.suffix === 'string') {
+              version = grunt.template.process(options.suffix);
+            } else {
+              version = options.suffix.map(function (suffix) {
+                return suffixes[suffix]();
+              }).join('-');
+            }
 
             var label = grunt.template.process(options.prefix || options.application || '') + '-' + version;
 

--- a/tasks/ebDeploy.js
+++ b/tasks/ebDeploy.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
               '-' + rev +
               '-' + Math.floor((Math.random() * 899999) + 100000);
 
-            var label = options.application + '-' + version;
+            var label = (options.prefix || options.application) + '-' + version;
 
             var account = data.User.Arn.split(/:/)[4];
             var bucket = 'elasticbeanstalk-' + options.region + '-' + account;


### PR DESCRIPTION
This allows you to specify a custom version label prefix instead of using the EB application name.
