### PR TITLE
Use STS.getCallerIdentity insteadof IAM.getUser

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "aws-sdk": "^2.1.8",
+    "aws-sdk": "^2.6.6",
     "git-rev": "^0.2.1",
     "grunt": "^0.4.5",
     "grunt-contrib-compress": "^0.13.0"

--- a/tasks/ebDeploy.js
+++ b/tasks/ebDeploy.js
@@ -43,9 +43,9 @@ module.exports = function(grunt) {
         console.log('Using credentials from profile \'' + options.profile + '\'');
       }
 
-      var iam = new AWS.IAM();
+      var sts = new AWS.STS();
 
-      iam.getUser({}, function(err, data) {
+      sts.getCallerIdentity({}, function(err, data) {
 
         if (err) {
 
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
 
             var label = options.application + '-' + version;
 
-            var account = data.User.Arn.split(/:/)[4];
+            var account = data.Account;
             var bucket = 'elasticbeanstalk-' + options.region + '-' + account;
 
             var body = fs.createReadStream(options.archive);


### PR DESCRIPTION
STS.getCallerIdentity contains the raw AccountID and requires no permissions, while IAM.getUser requires the getUser permission and requires parsing the user ARN.
